### PR TITLE
.gitignore typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ node_modules
 *.sw*
 
 # Use either yarn.lock or package-lock.json
-# Uncomment one of them to mainain a single lockfile
+# Uncomment one of them to maintain a single lockfile
 # package-lock.json
 # yarn.lock
 


### PR DESCRIPTION
### Change

Fix for a typo in the .gitignore file.
Changed "mainain" to "maintain".

### Does this PR introduce a breaking change?

No.

### What needs to be documented once your changes are merged?

Nothing.

### Additional Comments

Non.
